### PR TITLE
"usernamehas" to "username has", small typo

### DIFF
--- a/SOCVDBService/ini/regex_high_score.txt
+++ b/SOCVDBService/ini/regex_high_score.txt
@@ -1,4 +1,4 @@
-#These are the regex executed on comment where usernamehas been removed
+#These are the regex executed on comment where username has been removed
 (?i)be-nice\b
 (?i)this\s*(\w+)?\s*spam
 (?i)(flag.*spam)


### PR DESCRIPTION
"usernamehas" to "username has", small typo.